### PR TITLE
Feat: Replace sync listeners by async stream subscriptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+* Replace sync listeners by async stream subscriptions.
+* Prepare for the first official release.
+
 ## 0.1.0
 
 * Publish

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ pub.dartlang.org: (you can use 'any' instead of a version if you just want the l
 
 ```yaml
 dependencies:
-  fkafka: 0.1.0
+  fkafka: 1.0.0
 ```
 
 ```dart
@@ -51,12 +51,12 @@ kafka.emit(
 
 ## Listen
 
-Is necessary create a new instance to listen topics, try not use the same instance in more topics because is you try to close connection it will close in all topics listen in the same instance.
+To listen an specific topic you need to create a `Fkafka` instance.
 
 ```dart
 final kafka = Fkafka();
 
-kafka.on(
+kafka.listen(
   TulTopics.cart,
   (TopicData topic) {
     print(topic);
@@ -64,11 +64,17 @@ kafka.on(
 );
 ```
 
-## Close connection
+Don't forget to close the instance if it's not going to be used anymore. This will cancel all the subscriptions added to that instance.
 
-This method allows you to close topic listener.
+```dart
+kafka.closeInstance();
+```
+
+## Close Fkafka
+
+This method should be called if Fkafka won't be used anymore in the code, to avoid having open streams or memory leaks.
 
 ```
-kafka.close();
+Fkafka.closeAll();
 ```
 

--- a/example/main.dart
+++ b/example/main.dart
@@ -1,0 +1,80 @@
+// ignore_for_file: avoid_print
+
+import 'dart:async';
+
+import 'package:fkafka/fkafka.dart';
+
+void main() async {
+  runZonedGuarded(
+    () async {
+      const testTopic = 'test_topic';
+
+      var i = 0;
+
+      final fkafka1 = Fkafka();
+      fkafka1.listen(
+        onTopic: (_) {
+          i++;
+        },
+        topic: testTopic,
+      );
+
+      final fkafka2 = Fkafka();
+      fkafka2.listen(
+        onTopic: (_) {
+          throw Exception();
+        },
+        topic: testTopic,
+      );
+
+      final fkafka3 = Fkafka();
+      fkafka3.listen(
+        onTopic: (_) {
+          i++;
+        },
+        topic: testTopic,
+      );
+
+      final fkafkaEmitter = Fkafka();
+      fkafkaEmitter.emit(
+        testTopic,
+      );
+      await Future.delayed(const Duration(seconds: 2));
+      print(i == 2);
+
+      var isListening = fkafka1.isListeningTo(
+        topic: testTopic,
+      );
+      print(isListening == true);
+      fkafka1.pauseListeningTo(
+        topic: testTopic,
+      );
+      isListening = fkafka1.isListeningTo(
+        topic: testTopic,
+      );
+      print(isListening == false);
+
+      fkafkaEmitter.emit(
+        testTopic,
+      );
+      await Future.delayed(const Duration(seconds: 2));
+      print(i == 3);
+
+      fkafka1.resumeListeningTo(
+        topic: testTopic,
+      );
+      isListening = fkafka1.isListeningTo(
+        topic: testTopic,
+      );
+      print(isListening == true);
+
+      fkafka1.closeInstance();
+      fkafka2.closeInstance();
+      fkafka3.closeInstance();
+      fkafkaEmitter.closeInstance();
+
+      Fkafka.closeAll();
+    },
+    (_, __) {},
+  );
+}

--- a/lib/fkafka.dart
+++ b/lib/fkafka.dart
@@ -1,66 +1,149 @@
 library fkafka;
 
-import 'package:uuid/uuid.dart';
+import 'dart:async';
 
-part 'package:fkafka/models/subscriber.dart';
+import 'package:equatable/equatable.dart';
+
+part 'package:fkafka/models/event.dart';
 part 'package:fkafka/models/producer.dart';
+part 'package:fkafka/models/subscriber.dart';
 part 'package:fkafka/models/topic.dart';
 
 typedef OnTopicCallBack = void Function(TopicData topic);
 
 class Fkafka {
-  static final List<FkafkaSubscriber> _listeners = [];
-  final _uuid = const Uuid().v1();
+  static final Map<String, StreamController<FkafkaEvent>> _controllers = {};
 
-  /// Emit [topic] to all listeners
+  final Map<String, List<FkafkaSubscriber>> _subscribers = {};
+
+  /// Should be called whenever Fkafka itself is not going to be
+  /// used anymore.
+  static void closeAll() {
+    for (final controller in _controllers.values) {
+      controller.close();
+    }
+    _controllers.clear();
+  }
+
+  /// Emit an event to all subscribers of [topic].
   void emit(String topic, [TopicData topicData = const TopicData()]) {
-    try {
-      _listeners.where((k) => k.topic == topic && k.active).forEach((k) {
-        final data = topicData.copyWith(
-          topic: topic,
-        );
+    _controllers.putIfAbsent(
+      topic,
+      () => StreamController.broadcast(),
+    );
 
-        k.onTopic(data);
-      });
-    } catch (_) {}
-  }
-
-  /// Listen come [topic]
-  void on(String topic, OnTopicCallBack onTopic) {
-    try {
-      _listeners.add(
-        FkafkaSubscriber(
-          uuid: _uuid,
+    _controllers[topic]!.add(
+      FkafkaEvent(
+        topic: topic,
+        topicData: topicData.copyWith(
           topic: topic,
-          onTopic: onTopic,
         ),
+      ),
+    );
+  }
+
+  /// Add a subscription to the [topic]
+  void listen({
+    required OnTopicCallBack onTopic,
+    required String topic,
+  }) {
+    _controllers.putIfAbsent(
+      topic,
+      () => StreamController.broadcast(),
+    );
+    _subscribers.putIfAbsent(
+      topic,
+      () => [],
+    );
+
+    final subscription = _controllers[topic]!.stream.listen(
+      (event) {
+        onTopic(
+          event.topicData,
+        );
+      },
+    );
+    _subscribers[topic]!.add(
+      FkafkaSubscriber(
+        isActive: true,
+        onTopic: onTopic,
+        subscription: subscription,
+      ),
+    );
+  }
+
+  /// Pause all the subscriptions from this instance of Fkafka to
+  /// the [topic].
+  void pauseListeningTo({
+    required String topic,
+  }) {
+    _controllers.putIfAbsent(
+      topic,
+      () => StreamController.broadcast(),
+    );
+
+    final subscribers = _subscribers[topic] ?? <FkafkaSubscriber>[];
+
+    for (var i = 0; i < subscribers.length; i++) {
+      final subscriber = subscribers[i];
+      subscriber.subscription.cancel();
+
+      subscribers[i] = subscriber.copyWith(
+        isActive: false,
       );
-    } catch (_) {}
+    }
   }
 
-  /// Close connection from topic [topic] listener
-  void close() {
-    if (index == -1) return;
+  /// Resume all the subscriptions from this instance of Fkafka to
+  /// the [topic].
+  void resumeListeningTo({
+    required String topic,
+  }) {
+    _controllers.putIfAbsent(
+      topic,
+      () => StreamController.broadcast(),
+    );
 
-    try {
-      _listeners[index] = _listeners[index].copyWith(active: false);
-    } catch (_) {}
+    final subscribers = _subscribers[topic] ?? <FkafkaSubscriber>[];
+
+    for (var i = 0; i < subscribers.length; i++) {
+      final subscriber = subscribers[i];
+      subscriber.subscription.cancel();
+
+      final subscription = _controllers[topic]!.stream.listen(
+        (event) {
+          subscriber.onTopic(
+            event.topicData,
+          );
+        },
+      );
+
+      subscribers[i] = subscriber.copyWith(
+        isActive: true,
+        subscription: subscription,
+      );
+    }
   }
 
-  /// ReOpen active connection, if connection is already closed from topic [topic] listener
-  void reOpen() {
-    if (index == -1) return;
-
-    try {
-      _listeners[index] = _listeners[index].copyWith(active: true);
-    } catch (_) {}
+  /// Check if there is at least one active subscription to the
+  /// [topic] in this instance of Fkafka.
+  bool isListeningTo({
+    required String topic,
+  }) {
+    return _subscribers[topic]?.isNotEmpty == true &&
+        _subscribers[topic]!.any(
+          (subscriber) => subscriber.isActive,
+        );
   }
 
-  bool get listening {
-    if (index == -1) return false;
-
-    return _listeners[index].active;
+  /// Should be called whenever the instance of this Fkafka object is
+  /// not going to be used anymore.
+  void closeInstance() {
+    for (final subscribers in _subscribers.values) {
+      for (final subscriber in subscribers) {
+        subscriber.subscription.cancel();
+      }
+    }
+    _subscribers.clear();
   }
-
-  int get index => _listeners.indexWhere((k) => k.uuid == _uuid);
 }

--- a/lib/models/event.dart
+++ b/lib/models/event.dart
@@ -1,0 +1,17 @@
+part of 'package:fkafka/fkafka.dart';
+
+class FkafkaEvent extends Equatable {
+  const FkafkaEvent({
+    required this.topic,
+    required this.topicData,
+  });
+
+  final String topic;
+  final TopicData topicData;
+
+  @override
+  List<Object?> get props => [
+        topic,
+        topicData,
+      ];
+}

--- a/lib/models/subscriber.dart
+++ b/lib/models/subscriber.dart
@@ -1,29 +1,32 @@
 part of 'package:fkafka/fkafka.dart';
 
-class FkafkaSubscriber {
-  final String uuid;
-  final String topic;
-  final OnTopicCallBack onTopic;
-  final bool active;
-
+class FkafkaSubscriber extends Equatable {
   const FkafkaSubscriber({
-    required this.uuid,
-    required this.topic,
+    required this.isActive,
     required this.onTopic,
-    this.active = true,
+    required this.subscription,
   });
 
+  final bool isActive;
+  final OnTopicCallBack onTopic;
+  final StreamSubscription<FkafkaEvent> subscription;
+
   FkafkaSubscriber copyWith({
-    String? uuid,
-    String? topic,
+    bool? isActive,
     OnTopicCallBack? onTopic,
-    bool? active,
+    StreamSubscription<FkafkaEvent>? subscription,
   }) {
     return FkafkaSubscriber(
-      uuid: uuid ?? this.uuid,
-      topic: topic ?? this.topic,
+      isActive: isActive ?? this.isActive,
       onTopic: onTopic ?? this.onTopic,
-      active: active ?? this.active,
+      subscription: subscription ?? this.subscription,
     );
   }
+
+  @override
+  List<Object?> get props => [
+        isActive,
+        onTopic,
+        subscription,
+      ];
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fkafka
 description: Kafka equivalent in flutter
-version: 0.1.0
+version: 1.0.0
 homepage: https://github.com/AndresC17/fkafka
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  uuid: ^3.0.6
+  equatable: ^2.0.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR:

- Allows Fkafka to use async subscriptions instead of sync listeners.
- Fixes the problem when an Exception was thrown from any of the registered callbacks, stopping all of the pending listener calls to happen.
- Add an example with the basic usage of the package.
- Prepare package for first release.